### PR TITLE
Add `tag_command` functionality with tests and support for annotated tags creation and push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
-.idea/
-.claude/
+.data/
+!.pixi/config.toml
 *$py.class
 *.aof
 *.cover
 *.egg
 *.egg-info/
 *.iws
+*.lcov
 *.log
 *.manifest
 *.mo
@@ -22,6 +23,7 @@
 .Python
 .abstra/
 .cache
+.claude/
 .coverage
 .coverage.*
 .dmypy.json
@@ -29,6 +31,7 @@
 .env
 .envrc
 .hypothesis/
+.idea/
 .idea/**/aws.xml
 .idea/**/contentModel.xml
 .idea/**/copilot.data.migration.*.xml
@@ -52,7 +55,7 @@
 .idea/caches/build_file_checksums.ser
 .idea/httpRequests
 .idea/replstate.xml
-.idea/sonarlint.xml # see https://community.sonarsource.com/t/is-the-file-idea-idea-idea-sonarlint-xml-intended-to-be-under-source-control/121119
+.idea/sonarlint.xml
 .idea/sonarlint/
 .idea_modules/
 .installed.cfg
@@ -63,6 +66,7 @@
 .pdm-python
 .pdm.toml
 .pixi
+.pixi/*
 .pybuilder/
 .pypirc
 .pyre/
@@ -87,6 +91,7 @@ activemq-data/
 atlassian-ide-plugin.xml
 build/
 celerybeat-schedule
+celerybeat-schedule*
 celerybeat.pid
 cmake-build-*/
 com_crashlytics_export_strings.xml
@@ -127,6 +132,7 @@ rabbitmq/
 sdist/
 share/python-wheels/
 target/
+tempCodeRunnerFile.py
 var/
 venv.bak/
 venv/

--- a/core/command_wrappers.py
+++ b/core/command_wrappers.py
@@ -1,10 +1,12 @@
 import os
 from pathlib import Path
 
+from git import Repo
+
 from core.config import filter_disabled
 from core.diagnostics import preflight_check, suggest_fix
 from core.exceptions import GitAliasError
-from core.git_manager import config_repo
+from core.git_manager import checkout_branch, config_repo, create_tag, pull, push_tag
 from core.providers.registry import DEFAULT_PROVIDERS, get_provider
 from core.repo_analyzer import (
     detect_repo_name,
@@ -116,8 +118,6 @@ def fix_create_command(provider_names: list[str] | None = None) -> None:
     if not is_git_repo(cwd):
         config_repo(cwd, new_urls)
     else:
-        from git import Repo
-
         repo = Repo(cwd)
         if "origin" in [r.name for r in repo.remotes]:
             origin = repo.remote("origin")
@@ -156,8 +156,6 @@ def add_remote_command(
     url = provider.create_repo(repo_name)
     logger.info(f"Created {provider.display_name} repo: {url}")
 
-    from git import Repo
-
     repo = Repo(cwd)
 
     if set_fetch:
@@ -182,3 +180,31 @@ def add_remote_command(
         else:
             repo.create_remote("origin", url)
         logger.info(f"Added {provider.display_name} as push URL")
+
+
+def tag_command(
+    tag_name: str,
+    message: str | None = None,
+    push: bool = False,
+) -> None:
+    logger = get_logger()
+    cwd = Path(os.getcwd())
+
+    if not is_git_repo(cwd):
+        logger.error("Not a git repository. Cannot create tag.")
+        return
+
+    repo = Repo(cwd)
+    message = message or f"New version: {tag_name}"
+
+    checkout_branch(repo, "master")
+    pull(repo)
+    create_tag(repo, tag_name, message)
+
+    if push:
+        push_tag(repo, tag_name)
+    else:
+        logger.info(
+            f"Tag '{tag_name}' created locally. "
+            f"Push with: git push origin {tag_name}"
+        )

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -12,3 +12,7 @@ class ProviderCommandError(GitAliasError):
 
 class RepoCreationError(GitAliasError):
     """Raised when repository creation fails."""
+
+
+class GitOperationError(GitAliasError):
+    """Raised when a git operation (checkout, pull, tag, push) fails."""

--- a/core/git_manager.py
+++ b/core/git_manager.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 
-from git import Repo
+from git import GitCommandError, Repo
 
 from core.decorators import stop_watch
+from core.exceptions import GitOperationError
 from core.utils import get_logger
 
 _tag = "[Git]"
@@ -28,3 +29,47 @@ def _repo_remote_setup(repo: Repo, remote_repo_urls: list[str]) -> None:
 def config_repo(folder_path: Path, remote_repo_urls: list[str]) -> None:
     repo = _init_repo(folder_path)
     _repo_remote_setup(repo, remote_repo_urls)
+
+
+@stop_watch(f"{_tag} Checkout branch.")
+def checkout_branch(repo: Repo, branch: str = "master") -> None:
+    logger = get_logger()
+    logger.info(f"{_tag} Checking out branch '{branch}'")
+    try:
+        repo.heads[branch].checkout()
+    except IndexError as e:
+        raise GitOperationError(f"Branch '{branch}' not found") from e
+
+
+@stop_watch(f"{_tag} Pull latest changes.")
+def pull(repo: Repo) -> None:
+    logger = get_logger()
+    logger.info(f"{_tag} Pulling latest changes from origin")
+    try:
+        repo.remotes.origin.pull()
+    except GitCommandError as e:
+        raise GitOperationError(f"Pull failed: {e}") from e
+
+
+@stop_watch(f"{_tag} Create tag.")
+def create_tag(repo: Repo, tag_name: str, message: str) -> None:
+    logger = get_logger()
+    logger.info(f"{_tag} Creating tag '{tag_name}'")
+    try:
+        repo.create_tag(tag_name, message=message)
+    except GitCommandError as e:
+        raise GitOperationError(f"Failed to create tag '{tag_name}': {e}") from e
+
+
+@stop_watch(f"{_tag} Push tag.")
+def push_tag(repo: Repo, tag_name: str) -> None:
+    logger = get_logger()
+    logger.info(f"{_tag} Pushing tag '{tag_name}' to origin")
+    try:
+        result = repo.remotes.origin.push(tag_name)
+        if result and result[0].flags & result[0].ERROR:
+            raise GitOperationError(
+                f"Push rejected for tag '{tag_name}': {result[0].summary}"
+            )
+    except GitCommandError as e:
+        raise GitOperationError(f"Failed to push tag '{tag_name}': {e}") from e

--- a/g.py
+++ b/g.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 
-from core.command_wrappers import add_remote_command, create_command, fix_create_command
+from core.command_wrappers import add_remote_command, create_command, fix_create_command, tag_command
 from core.config import disable_provider, enable_provider, is_provider_disabled
 from core.diagnostics import doctor
 from core.exceptions import GitAliasError
@@ -79,6 +79,23 @@ enable_parser.add_argument(
     help="Provider to enable",
 )
 
+# tag
+tag_parser = subparsers.add_parser(
+    "tag", help="Create an annotated tag on master."
+)
+tag_parser.add_argument("tag_name", type=str, help="Name of the tag")
+tag_parser.add_argument(
+    "-m",
+    "--message",
+    type=str,
+    help="Tag message (default: 'New version: <tag_name>')",
+)
+tag_parser.add_argument(
+    "--push",
+    action="store_true",
+    help="Push the tag to origin after creation",
+)
+
 # doctor
 subparsers.add_parser("doctor", help="Run diagnostics and report system status.")
 
@@ -107,6 +124,8 @@ def main():
                 enable_provider(args.provider)
                 print(f"Enabled {args.provider}.")
                 print(f"Use 'g fix-create' to create repos on any missing providers.")
+        elif args.command == "tag":
+            tag_command(args.tag_name, args.message, args.push)
         elif args.command == "doctor":
             doctor()
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "git-alias2"
-version = "2.0.0"
+version = "2.1.0"
 description = "Git aliases for multi-provider repository management"
 requires-python = ">=3.10"
 dependencies = [
-    "GitPython>=3.1.48",
+    "GitPython>=3.1.49",
     "raccoontools>=2.0.1",
 ]
 

--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,20 @@ Options:
 g add-remote gitlab --repo-name my-repo --set-fetch
 ```
 
+### `g tag <tag_name>`
+Creates an annotated tag on the `master` branch. Checks out `master`, pulls the latest changes, then creates the tag:
+```shell
+g tag v1.0.0
+```
+
+Options:
+- `-m, --message <message>` — custom tag message (default: `"New version: <tag_name>"`)
+- `--push` — push the tag to origin after creation
+
+```shell
+g tag v1.0.0 -m "Release 1.0.0" --push
+```
+
 ## Running Tests
 ```shell
 uv run pytest

--- a/tests/test_tag_command.py
+++ b/tests/test_tag_command.py
@@ -1,0 +1,115 @@
+from unittest.mock import MagicMock, call, patch
+
+from core.command_wrappers import tag_command
+
+
+class TestTagCommand:
+    @patch("core.command_wrappers.push_tag")
+    @patch("core.command_wrappers.create_tag")
+    @patch("core.command_wrappers.pull")
+    @patch("core.command_wrappers.checkout_branch")
+    @patch("core.command_wrappers.Repo")
+    @patch("core.command_wrappers.is_git_repo", return_value=True)
+    def test_creates_tag_with_default_message(
+        self, mock_is_git, mock_repo, mock_checkout, mock_pull,
+        mock_create_tag, mock_push,
+    ):
+        repo_instance = MagicMock()
+        mock_repo.return_value = repo_instance
+
+        tag_command("v1.0.0")
+
+        mock_create_tag.assert_called_once_with(
+            repo_instance, "v1.0.0", "New version: v1.0.0"
+        )
+
+    @patch("core.command_wrappers.push_tag")
+    @patch("core.command_wrappers.create_tag")
+    @patch("core.command_wrappers.pull")
+    @patch("core.command_wrappers.checkout_branch")
+    @patch("core.command_wrappers.Repo")
+    @patch("core.command_wrappers.is_git_repo", return_value=True)
+    def test_creates_tag_with_custom_message(
+        self, mock_is_git, mock_repo, mock_checkout, mock_pull,
+        mock_create_tag, mock_push,
+    ):
+        repo_instance = MagicMock()
+        mock_repo.return_value = repo_instance
+
+        tag_command("v2.0.0", message="Big release!")
+
+        mock_create_tag.assert_called_once_with(
+            repo_instance, "v2.0.0", "Big release!"
+        )
+
+    @patch("core.command_wrappers.push_tag")
+    @patch("core.command_wrappers.create_tag")
+    @patch("core.command_wrappers.pull")
+    @patch("core.command_wrappers.checkout_branch")
+    @patch("core.command_wrappers.Repo")
+    @patch("core.command_wrappers.is_git_repo", return_value=True)
+    def test_pushes_tag_when_flag_set(
+        self, mock_is_git, mock_repo, mock_checkout, mock_pull,
+        mock_create_tag, mock_push,
+    ):
+        repo_instance = MagicMock()
+        mock_repo.return_value = repo_instance
+
+        tag_command("v1.0.0", push=True)
+
+        mock_push.assert_called_once_with(repo_instance, "v1.0.0")
+
+    @patch("core.command_wrappers.push_tag")
+    @patch("core.command_wrappers.create_tag")
+    @patch("core.command_wrappers.pull")
+    @patch("core.command_wrappers.checkout_branch")
+    @patch("core.command_wrappers.Repo")
+    @patch("core.command_wrappers.is_git_repo", return_value=True)
+    def test_does_not_push_when_flag_not_set(
+        self, mock_is_git, mock_repo, mock_checkout, mock_pull,
+        mock_create_tag, mock_push,
+    ):
+        tag_command("v1.0.0")
+
+        mock_push.assert_not_called()
+
+    @patch("core.command_wrappers.push_tag")
+    @patch("core.command_wrappers.create_tag")
+    @patch("core.command_wrappers.pull")
+    @patch("core.command_wrappers.checkout_branch")
+    @patch("core.command_wrappers.Repo")
+    @patch("core.command_wrappers.is_git_repo", return_value=False)
+    def test_errors_when_not_git_repo(
+        self, mock_is_git, mock_repo, mock_checkout, mock_pull,
+        mock_create_tag, mock_push,
+    ):
+        tag_command("v1.0.0")
+
+        mock_repo.assert_not_called()
+        mock_checkout.assert_not_called()
+        mock_create_tag.assert_not_called()
+
+    @patch("core.command_wrappers.push_tag")
+    @patch("core.command_wrappers.create_tag")
+    @patch("core.command_wrappers.pull")
+    @patch("core.command_wrappers.checkout_branch")
+    @patch("core.command_wrappers.Repo")
+    @patch("core.command_wrappers.is_git_repo", return_value=True)
+    def test_checkout_and_pull_before_tag(
+        self, mock_is_git, mock_repo, mock_checkout, mock_pull,
+        mock_create_tag, mock_push,
+    ):
+        repo_instance = MagicMock()
+        mock_repo.return_value = repo_instance
+
+        # Use a shared call tracker to verify ordering
+        call_order = []
+        mock_checkout.side_effect = lambda *a, **kw: call_order.append("checkout")
+        mock_pull.side_effect = lambda *a, **kw: call_order.append("pull")
+        mock_create_tag.side_effect = lambda *a, **kw: call_order.append("create_tag")
+
+        tag_command("v1.0.0")
+
+        assert call_order == ["checkout", "pull", "create_tag"]
+        mock_checkout.assert_called_once_with(repo_instance, "master")
+        mock_pull.assert_called_once_with(repo_instance)

--- a/uv.lock
+++ b/uv.lock
@@ -148,7 +148,7 @@ wheels = [
 
 [[package]]
 name = "git-alias2"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },
@@ -162,7 +162,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "gitpython", specifier = ">=3.1.48" },
+    { name = "gitpython", specifier = ">=3.1.49" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "raccoontools", specifier = ">=2.0.1" },
 ]
@@ -182,14 +182,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.48"
+version = "3.1.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/c3/e4a9656f3cdb280f5dc65a68cc6fc46e79f897d27c1a36bbb4f0f47aaac5/gitpython-3.1.48.tar.gz", hash = "sha256:b7c49ff4a49946fce38ac84116efa311b15e7dad06dc3787fc9e206bf9ef75e1", size = 217288, upload-time = "2026-04-28T05:35:45.328Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/50/bb9703c364c00e7be67ccda03536f3d684766ce109d184c9d1f072d866ca/gitpython-3.1.48-py3-none-any.whl", hash = "sha256:737698b05889cca0f9aba7054d796620df2092c68926ee1470e5c7f5ac886680", size = 209800, upload-time = "2026-04-28T05:35:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Introduced `tag_command` for creating annotated tags.
- Added CLI support for the `tag` command with options for custom messages and automatic push.
- Implemented tests to cover branching, pulling, tagging, and error handling scenarios.
- Updated dependency `GitPython` to version 3.1.49 and increased package version to 2.1.0.